### PR TITLE
Fixed: Now haigha can load records without id column

### DIFF
--- a/src/TableRecordInstantiator.php
+++ b/src/TableRecordInstantiator.php
@@ -38,12 +38,6 @@ class TableRecordInstantiator implements MethodInterface
         $tablename = substr($fixture->getClass(), 6);
         $r = new TableRecord($tablename);
 
-        if (!isset($this->ids[$tablename])) {
-            $this->ids[$tablename] = 1;
-        }
-        $r->setId($this->ids[$tablename]);
-        $this->ids[$tablename]++;
-
         if ($this->auto_uuid_column) {
             $uuid = (string)Uuid::uuid4();
             $r->setR_uuid($uuid);


### PR DESCRIPTION
This has no sense as usually `id` fields is auto incremented.

Also, this lines caused error like this if there is no `id` field on table:

```
Error: 'Unknown column 'id' in 'field list'' on query 'INSERT INTO account (id, display_name, currency) VALUES (:id, :display_name, :currency);' 
```
