### PR TITLE
Avoid truncating the same table multiple times

### DIFF
--- a/src/Persister/PdoPersister.php
+++ b/src/Persister/PdoPersister.php
@@ -28,8 +28,12 @@ class PdoPersister implements PersisterInterface
      */
     public function reset($objects)
     {
+        $truncated = array();
         foreach ($objects as $object) {
             $tablename = $object->__meta('tablename');
+            if (in_array($tablename, $truncated, true)) {
+                continue;
+            }
             $sql = sprintf("TRUNCATE `%s`", $tablename);
 
             if ($this->dryRun) {
@@ -40,6 +44,7 @@ class PdoPersister implements PersisterInterface
             $this->output->writeln(sprintf("Executing: %s", $sql));
             $statement = $this->pdo->prepare($sql);
             $statement->execute();
+            $truncated[] = $tablename;
         }
     }
 


### PR DESCRIPTION
When storing many objects of the same class we get the same truncate executed once for each object which is not necessary.

I am not sure if it's a misuse of haigha or if it's an omission on your end but I hope this is a good fix
